### PR TITLE
Fix bug which prevents users from accessing their own decks and cards

### DIFF
--- a/decks/views.py
+++ b/decks/views.py
@@ -38,7 +38,7 @@ class ShareableDeckMixin(LoginRequiredMixin, PermissionRequiredMixin):
     @override
     def has_permission(self: ObjectViewProtocol[Deck]):
         return (
-            self.get_object().owner == self.request
+            self.get_object().owner == self.request.user
             or self.get_object().published == True
         )
 
@@ -102,7 +102,7 @@ class ShareableCardMixin(LoginRequiredMixin, PermissionRequiredMixin):
     @override
     def has_permission(self: ObjectViewProtocol[Card]):
         return (
-            self.get_object().deck.owner == self.request
+            self.get_object().deck.owner == self.request.user
             or self.get_object().deck.published == True
         )
 


### PR DESCRIPTION
Quick fix - the buggy code compared the deck's owner with `request` instead of `request.user`, which would clearly never hold since they're the wrong types.